### PR TITLE
WIP on private tags with explicit VR

### DIFF
--- a/src/dicom_parser/header.py
+++ b/src/dicom_parser/header.py
@@ -23,7 +23,10 @@ from dicom_parser.utils.private_tags import PRIVATE_TAGS
 from dicom_parser.utils.sequence_detector.sequence_detector import (
     SequenceDetector,
 )
-from dicom_parser.utils.value_representation import ValueRepresentation
+from dicom_parser.utils.value_representation import (
+    ValueRepresentation,
+    get_value_representation,
+)
 from dicom_parser.utils.vr_to_data_element import get_data_element_class
 
 
@@ -358,6 +361,10 @@ class Header:
             raw_element = tag_or_keyword
         DataElementClass = get_data_element_class(raw_element)
         data_element = DataElementClass(raw_element)
+        # Fix private data elements with an explicit VR.
+        if data_element.is_private and raw_element.VR != "UN":
+            value_representation = get_value_representation(raw_element.VR)
+            data_element.VALUE_REPRESENTATION = value_representation
         # This prevents a circular import but it's far from optimal.
         if data_element.VALUE_REPRESENTATION == ValueRepresentation.SQ:
             data_element._value = [

--- a/src/dicom_parser/utils/vr_to_data_element.py
+++ b/src/dicom_parser/utils/vr_to_data_element.py
@@ -2,8 +2,6 @@
 Utilities to associate a given data element with its appropriate
 :class:`dicom_parser.data_element.DataElement` subclass.
 """
-from pydicom.dataelem import DataElement as PydicomDataElement
-
 from dicom_parser.data_element import DataElement
 from dicom_parser.data_elements.age_string import AgeString
 from dicom_parser.data_elements.application_entity import ApplicationEntity
@@ -29,7 +27,9 @@ from dicom_parser.data_elements.other_long import OtherLong
 from dicom_parser.data_elements.other_word import OtherWord
 from dicom_parser.data_elements.person_name import PersonName
 from dicom_parser.data_elements.private_data_element import (
-    PrivateDataElement, TAG_TO_DEFINITION as PRIVATE_TAG_TO_DEFINITION)
+    TAG_TO_DEFINITION as PRIVATE_TAG_TO_DEFINITION,
+)
+from dicom_parser.data_elements.private_data_element import PrivateDataElement
 from dicom_parser.data_elements.sequence_of_items import SequenceOfItems
 from dicom_parser.data_elements.short_string import ShortString
 from dicom_parser.data_elements.short_text import ShortText
@@ -48,10 +48,12 @@ from dicom_parser.data_elements.unsigned_64bit_very_long import (
 from dicom_parser.data_elements.unsigned_long import UnsignedLong
 from dicom_parser.data_elements.unsigned_short import UnsignedShort
 from dicom_parser.data_elements.url import Url
+from dicom_parser.utils.parse_tag import parse_tag
 from dicom_parser.utils.value_representation import (
     ValueRepresentation,
     get_value_representation,
 )
+from pydicom.dataelem import DataElement as PydicomDataElement
 
 #: A dictionary associating the various value representations with their
 #: appropriate :class:`dicom_parser.data_element.DataElement` subclasses.
@@ -108,7 +110,7 @@ def get_data_element_class(element: PydicomDataElement) -> DataElement:
     DataElement
         Some subclass of DataElement
     """
-    if element.tag in PRIVATE_TAG_TO_DEFINITION:
+    if parse_tag(element.tag) in PRIVATE_TAG_TO_DEFINITION:
         return PrivateDataElement
     vr = get_value_representation(element.VR)
     return VR_TO_DATA_ELEMENT[vr]

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -337,8 +337,10 @@ class HeaderTestCase(TestCase):
         self.assertEqual(len(value), 120)
 
     def test_unknown_value_representation(self):
+        data_element = self.header.get_data_element("SeriesDate").raw
+        data_element.VR = "??"
         with self.assertRaises(ValueRepresentationError):
-            get_data_element_class("invalid")
+            get_data_element_class(data_element)
 
     def test_get_phase_encoding_direction(self):
         value = self.dwi_header.get_phase_encoding_direction()


### PR DESCRIPTION
Added parse_tag() function to mediate pydicom's Tag with the TAG_TO_DEFINITION dictionary. Fixed tests.